### PR TITLE
docs: update readme with xs-dev info

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ To enable JavaScript (aka ECMAScript) developers to explore the world of microco
 * Windows users should:
   1. Download the Microsoft Visual Studio 2022 Community installer.
   2. Launch the installer. On the "Workloads" tab, select the "Desktop development for C++" option. On the "Individual Components" tab, select "Windows 10 SDK (10.0.19041.0)" (this should be preselected on Windows 10 systems but must be manually included on Windows 11 systems). Proceed with the installation as configured.
-* @hipsterbrown Should we ask them to use xs-dev or to do any other pre-work? Internet and wi-fi quality are TBD
+* For Mac and Linux users, install [`xs-dev`](https://github.com/HipsterBrown/xs-dev#install) and go through the [setup process](https://github.com/HipsterBrown/xs-dev#moddable-sdk-setup--update--teardown)
+  * [Windows support coming soon](https://github.com/HipsterBrown/xs-dev/pull/44)
 
 ## Workshop goals (the first two hours)
 * Moddable SDK install & setup
@@ -38,6 +39,8 @@ To enable JavaScript (aka ECMAScript) developers to explore the world of microco
 
 ## Post workshop goals (office hours)
 * Interface with a 3rd party API via wi-fi and do something with your hardware
+* Create embedded web server to interact with hardware
+* Display sensor data on ePaper screen
 
 ## BOM [Google sheet with links and prices](https://docs.google.com/spreadsheets/d/1mZAw3TPqquWeDhawjyudr1aHb2-XNfY4TG3rIGlpbOc/edit?usp=sharing)
 * Moddable 3 (includes ePaper display)


### PR DESCRIPTION
Creating a PR for discussion around workshop details, include pre-work and post-work ideas. 

I'd like to advocate for folks familiar with JS / Node to get as far as they can with the setup using `xs-dev`. That will save a bunch of time and bandwidth at the workshop, which can be used to cover more of the programming basics. Hopefully, the Windows support will be solid enough by August to provide a streamlined experience for those machines as well. 

Open questions:

1. Are we planning to use j5e? If yes, do we want to include that in the setup instructions?
2. How "self-hostable" should the instructions for this workshop be?
3. Do we want to mention npm if we can't take advantage of it for Moddable projects yet?
4. Should we mention ECMA-419 in the "Goal" or "Why is JS ideal for hardware?" sections?